### PR TITLE
Add multi-architecture support (amd64 + arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
-arg dev_mode=false
+ARG BUILDPLATFORM
+ARG TARGETARCH
+ARG dev_mode=false
 WORKDIR /workspace
 # Copy go.mod and go.sum based on mode
 COPY go.mod ./
@@ -14,7 +16,7 @@ RUN if [ "$dev_mode" = "true" ]; then \
     fi
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kubevirt-vm-to-pod ./cmd
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o kubevirt-vm-to-pod ./cmd
 
 # Final image
 FROM gcr.io/distroless/static:nonroot

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,5 +1,7 @@
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
+ARG BUILDPLATFORM
+ARG TARGETARCH
 ARG dev_mode=false
 WORKDIR /workspace
 COPY go.mod ./
@@ -13,7 +15,7 @@ RUN if [ "$dev_mode" = "true" ]; then \
     fi
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o console-proxy ./cmd/proxy && \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o console-proxy ./cmd/proxy && \
     chmod 755 console-proxy
 
 FROM gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,13 @@ PODMAN_TAG ?= latest
 PODMAN_IMG ?= $(PODMAN_REPO):$(PODMAN_TAG)
 PROXY_BINARY_NAME ?= console-proxy
 
-GO_BUILD_ENV ?= CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+GO_BUILD_ENV ?= CGO_ENABLED=0 GOOS=linux
+PLATFORMS ?= linux/amd64,linux/arm64
 GO_TEST_FLAGS ?= -v -race
 
 DEV_MODE ?= false  # Set to true for dev builds (dynamically replaces KubeVirt dep with main branch)
 
-.PHONY: all build test podman-build podman-build-dev podman-push clean build-proxy podman-build-proxy podman-push-proxy functional-test functional-test-proxy functional-test-quick functional-test-all run stop
+.PHONY: all build test podman-build podman-build-dev podman-push podman-build-multiarch podman-push-multiarch clean build-proxy podman-build-proxy podman-push-proxy functional-test functional-test-proxy functional-test-quick functional-test-all run stop
 
 all: build test build-proxy
 
@@ -33,6 +34,12 @@ podman-build-dev: podman-build-proxy
 
 podman-push: podman-push-proxy
 	podman push $(PODMAN_IMG)
+
+podman-build-multiarch:
+	podman build --platform $(PLATFORMS) --build-arg dev_mode=$(DEV_MODE) --manifest $(PODMAN_IMG) .
+
+podman-push-multiarch: podman-build-multiarch
+	podman manifest push $(PODMAN_IMG) docker://$(PODMAN_IMG)
 
 # Run a VM: make run VM=myvm.yaml
 run: podman-build

--- a/README.md
+++ b/README.md
@@ -314,6 +314,13 @@ make podman-build
 make podman-push
 ```
 
+### Multi-Architecture Build (amd64 + arm64)
+
+```bash
+# Build and push multi-arch manifest
+make podman-push-multiarch
+```
+
 ### Development Mode
 
 Build with local KubeVirt source:
@@ -370,6 +377,7 @@ VirtualMachine YAML
 
 - **KubeVirt Version**: v1.8.0
 - **Kubernetes APIs**: v0.34.2
+- **Architectures**: amd64, arm64
 - **Container Runtime**: Podman 4.x+, Docker (experimental)
 - **Host OS**: Linux with KVM support (for full VM boot)
 


### PR DESCRIPTION
Use TARGETARCH in Dockerfiles instead of hardcoded amd64, and remove GOARCH from local build env so it defaults to the host architecture.

Add podman-build-multiarch / podman-push-multiarch Makefile targets for building and publishing multi-arch manifest images.