### PR TITLE
feat: make access proxies default and add configurable ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Convert KubeVirt VirtualMachine definitions into standalone Pods that can run ou
 **Key Features:**
 - ✅ Converts VM to standalone Pod YAML
 - ✅ Supports Instancetype and Preference expansion
-- ✅ Optional console proxy sidecar for VM access
+- ✅ Access proxy sidecar for console and VNC access (enabled by default)
 - ✅ Passt network binding by default for standalone execution
 - ✅ Mount KVM devices for hardware virtualization
 - ✅ Compatible with Podman kube play
@@ -81,12 +81,14 @@ podman kube play pod.yaml
 | `--vm-file` | Path to VirtualMachine YAML file (also accepts positional arg or stdin) | stdin |
 | `--mount-devices` | Mount KVM devices (/dev/kvm, /dev/vhost-net, /dev/net/tun) for standalone execution | `true` |
 | `--no-passt` | Preserve original network bindings instead of converting to Passt (requires CNI plugins) | `false` |
-| `--add-console-proxy` | Add console proxy sidecar to the Pod | `false` |
+| `--add-access-proxies` | Add access proxy sidecar with console and VNC ports | `true` |
+| `--proxy-port` | Port for the console proxy to listen on | `28080` |
+| `--vnc-proxy-port` | Port for the VNC proxy to listen on | `15900` |
+| `--proxy-image` | Access proxy container image | `quay.io/vladikr/kubevirt-console-proxy:latest` |
+| `--add-console-proxy` | (Deprecated) Add console proxy sidecar (use --add-access-proxies) | `false` |
 | `--launcher-image` | Virt-launcher container image | `quay.io/kubevirt/virt-launcher:v1.8.0` |
 | `--instancetype-file` | Path to VirtualMachineInstancetype YAML file (optional) | - |
 | `--preference-file` | Path to VirtualMachinePreference YAML file (optional) | - |
-| `--proxy-image` | Console proxy container image | `quay.io/vladikr/kubevirt-console-proxy:latest` |
-| `--proxy-port` | Port for console proxy to listen on | `8080` |
 | `--output` | Output format: yaml or json | `yaml` |
 
 ## Usage Examples
@@ -113,16 +115,20 @@ podman kube play pod.yaml
   > pod.yaml
 ```
 
-### 3. VM with Console Proxy
+### 3. VM with Access Proxies (customizing ports)
 
 ```bash
-./kubevirt-vm-to-pod \
-  --vm-file=myvm.yaml \
-  --add-console-proxy \
-  --mount-devices \
-  > pod.yaml
+# Access proxies are enabled by default (console: 28080, VNC: 15900)
+./kubevirt-vm-to-pod myvm.yaml > pod.yaml
 
-podman kube play pod.yaml
+# Publish ports for external access
+podman kube play -p 28080:28080 -p 15900:15900 pod.yaml
+
+# Custom ports
+./kubevirt-vm-to-pod --proxy-port=9090 --vnc-proxy-port=5901 myvm.yaml > pod.yaml
+
+# Disable access proxies
+./kubevirt-vm-to-pod --add-access-proxies=false myvm.yaml > pod.yaml
 ```
 
 ### 4. VM with Original Network Bindings (CNI plugins required)
@@ -143,7 +149,6 @@ podman kube play pod.yaml
   --vm-file=myvm.yaml \
   --instancetype-file=instancetype.yaml \
   --preference-file=preference.yaml \
-  --add-console-proxy \
   --mount-devices \
   --launcher-image=quay.io/kubevirt/virt-launcher:v1.8.0 \
   > pod.yaml
@@ -213,20 +218,35 @@ networks:
     pod: {}
 ```
 
-### Console Proxy (`--add-console-proxy`)
+### Access Proxy (default)
 
-Adds a console proxy sidecar container for accessing the VM console.
+An access proxy sidecar is added by default for accessing the VM's serial console and VNC display.
 
 **Features:**
-- WebSocket-based console access
+- WebSocket-based console and VNC access
 - Shared volume with virt-launcher for socket communication
-- Configurable port (default: 8080)
+- Configurable ports (console default: 28080, VNC default: 15900)
+- No hostPort — use `podman kube play -p` for external access
 
-**Access the console:**
+**Ports:**
+- Console: 28080 (override with `--proxy-port`)
+- VNC: 15900 (override with `--vnc-proxy-port`)
+
+**Accessing the VM:**
 ```bash
-# After starting the Pod
-curl http://localhost:8080/console
-# Or use VNC/serial console clients
+# External access requires port forwarding
+podman kube play -p 28080:28080 -p 15900:15900 pod.yaml
+
+# Connect to serial console via WebSocket
+wscat -c ws://localhost:28080/console -s binary.kubevirt.io
+
+# VNC endpoint (once PR 2 implements VNC support)
+# A VNC client can connect to the /vnc WebSocket endpoint
+```
+
+**To disable the access proxy:**
+```bash
+./kubevirt-vm-to-pod --add-access-proxies=false myvm.yaml
 ```
 
 ## Sample VirtualMachine YAML
@@ -344,7 +364,7 @@ The generated Pod contains:
 - **compute container**: virt-launcher running the VM
 - **STANDALONE_VMI env var**: Embedded VMI specification
 - **Device mounts** (if `--mount-devices`): /dev/kvm, /dev/vhost-net, /dev/net/tun
-- **Console proxy sidecar** (if `--add-console-proxy`): WebSocket console access
+- **Access proxy sidecar** (default, disable with `--add-access-proxies=false`): WebSocket console and VNC access
 - **Volume containers**: For container disks and ephemeral storage
 
 ## Architecture
@@ -362,7 +382,7 @@ VirtualMachine YAML
         ↓
    [Pod Rendering]
         ↓
- [Optional: Console Proxy]
+ [Access Proxy (default)]
  [Passt Networking (default)]
  [Optional: Device Mounts]
         ↓

--- a/cmd/vmToPod.go
+++ b/cmd/vmToPod.go
@@ -25,8 +25,10 @@ var (
 	instancetypeFile string
 	preferenceFile   string
 	addConsoleProxy  bool
+	addAccessProxies bool
 	proxyImage       string
 	proxyPort        int
+	vncProxyPort     int
 	noPasst          bool
 	mountDevices     bool
 )
@@ -57,18 +59,41 @@ or piped through stdin:
 			if launcherImage == "" {
 				launcherImage = "quay.io/kubevirt/virt-launcher:v1.8.0"
 			}
-			if addConsoleProxy && proxyImage == "" {
+
+			// Resolve proxy flags with backward compatibility
+			effectiveAddProxies := addAccessProxies
+			useLegacyPath := false
+
+			if cmd.Flags().Changed("add-console-proxy") && !cmd.Flags().Changed("add-access-proxies") {
+				fmt.Fprintf(os.Stderr, "Warning: --add-console-proxy is deprecated, use --add-access-proxies instead\n")
+				effectiveAddProxies = addConsoleProxy
+				useLegacyPath = true
+			}
+
+			if effectiveAddProxies && proxyImage == "" {
 				proxyImage = "quay.io/vladikr/kubevirt-console-proxy:latest"
 			}
 
-			t := transformer.NewVMToPodTransformer(
-				transformer.WithLauncherImage(launcherImage),
-				transformer.WithInstancetypeFile(instancetypeFile),
-				transformer.WithPreferenceFile(preferenceFile),
-				transformer.WithAddConsoleProxy(addConsoleProxy, proxyImage, proxyPort),
-				transformer.WithForcePasst(!noPasst),
-				transformer.WithMountDevices(mountDevices),
-			)
+			var t *transformer.VMToPodTransformer
+			if useLegacyPath {
+				t = transformer.NewVMToPodTransformer(
+					transformer.WithLauncherImage(launcherImage),
+					transformer.WithInstancetypeFile(instancetypeFile),
+					transformer.WithPreferenceFile(preferenceFile),
+					transformer.WithAddConsoleProxy(addConsoleProxy, proxyImage, proxyPort),
+					transformer.WithForcePasst(!noPasst),
+					transformer.WithMountDevices(mountDevices),
+				)
+			} else {
+				t = transformer.NewVMToPodTransformer(
+					transformer.WithLauncherImage(launcherImage),
+					transformer.WithInstancetypeFile(instancetypeFile),
+					transformer.WithPreferenceFile(preferenceFile),
+					transformer.WithAddAccessProxies(effectiveAddProxies, proxyImage, proxyPort, vncProxyPort),
+					transformer.WithForcePasst(!noPasst),
+					transformer.WithMountDevices(mountDevices),
+				)
+			}
 
 			var pod *k8sv1.Pod
 			var err error
@@ -101,9 +126,11 @@ or piped through stdin:
 	rootCmd.Flags().StringVar(&launcherImage, "launcher-image", "", "Virt-launcher image (default: quay.io/kubevirt/virt-launcher:v1.8.0)")
 	rootCmd.Flags().StringVar(&instancetypeFile, "instancetype-file", "", "Path to Instancetype YAML file (optional)")
 	rootCmd.Flags().StringVar(&preferenceFile, "preference-file", "", "Path to Preference YAML file (optional)")
-	rootCmd.Flags().BoolVar(&addConsoleProxy, "add-console-proxy", false, "Add console proxy sidecar to the Pod")
+	rootCmd.Flags().BoolVar(&addConsoleProxy, "add-console-proxy", false, "Add console proxy sidecar to the Pod (deprecated, use --add-access-proxies)")
+	rootCmd.Flags().BoolVar(&addAccessProxies, "add-access-proxies", true, "Add access proxy sidecar with console and VNC ports (default: true)")
 	rootCmd.Flags().StringVar(&proxyImage, "proxy-image", "", "Console proxy image (default: quay.io/vladikr/kubevirt-console-proxy:latest)")
-	rootCmd.Flags().IntVar(&proxyPort, "proxy-port", 8080, "Port for the console proxy to listen on")
+	rootCmd.Flags().IntVar(&proxyPort, "proxy-port", 28080, "Port for the console proxy to listen on")
+	rootCmd.Flags().IntVar(&vncProxyPort, "vnc-proxy-port", 15900, "Port for the VNC proxy to listen on")
 	rootCmd.Flags().BoolVar(&noPasst, "no-passt", false, "Preserve original network bindings instead of converting to Passt (requires CNI plugins)")
 	rootCmd.Flags().BoolVar(&mountDevices, "mount-devices", true, "Mount KVM devices (/dev/kvm, /dev/vhost-net, /dev/net/tun) for standalone execution")
 

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -36,8 +36,10 @@ type VMToPodTransformer struct {
 	InstancetypeFile 	string
 	PreferenceFile   	string
 	AddConsoleProxy 	bool
+	AddAccessProxies	bool
 	ProxyImage      	string
 	ProxyPort       	int
+	VNCProxyPort    	int
 	ForcePasst      	bool
 	MountDevices    	bool
 }
@@ -79,6 +81,15 @@ func WithForcePasst(enabled bool) TransformerOption {
 func WithMountDevices(enabled bool) TransformerOption {
 	return func(t *VMToPodTransformer) {
 		t.MountDevices = enabled
+	}
+}
+
+func WithAddAccessProxies(enabled bool, image string, consolePort int, vncPort int) TransformerOption {
+	return func(t *VMToPodTransformer) {
+		t.AddAccessProxies = enabled
+		t.ProxyImage = image
+		t.ProxyPort = consolePort
+		t.VNCProxyPort = vncPort
 	}
 }
 
@@ -210,7 +221,19 @@ func (t *VMToPodTransformer) transformBytes(data []byte) (*k8sv1.Pod, error) {
 		pod.ObjectMeta.GenerateName = ""
 	}
 
-	if t.AddConsoleProxy {
+	if t.AddAccessProxies {
+		addAccessProxySidecar(pod, t.ProxyImage, t.ProxyPort, t.VNCProxyPort)
+		// Add warning annotation about proxy ports
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		pod.Annotations["kubevirt-vm-to-pod/proxy-ports"] = fmt.Sprintf(
+			"Access proxy ports (console: %d, vnc: %d) use containerPort only. "+
+			"If you need external access, use podman kube play with -p flags (e.g., -p %d:%d -p %d:%d). "+
+			"Ensure these ports do not conflict with other services.",
+			t.ProxyPort, t.VNCProxyPort, t.ProxyPort, t.ProxyPort, t.VNCProxyPort, t.VNCProxyPort)
+	} else if t.AddConsoleProxy {
+		// Backward compatibility: legacy console-only proxy
 		addConsoleProxySidecar(pod, t.ProxyImage, t.ProxyPort)
 	}
 
@@ -256,6 +279,35 @@ func addConsoleProxySidecar(pod *k8sv1.Pod, proxyImage string, proxyPort int) {
 		Name:    "console-proxy",
 		Image:   proxyImage,
 		Command: []string{"/console-proxy", fmt.Sprintf("-port=%d", proxyPort), "-listen=unix"},
+		VolumeMounts: []k8sv1.VolumeMount{
+			{Name: privateVolName, MountPath: "/var/run/kubevirt-private"},
+		},
+		SecurityContext: &k8sv1.SecurityContext{
+			Capabilities: &k8sv1.Capabilities{Drop: []k8sv1.Capability{"ALL"}},
+		},
+	})
+}
+
+func addAccessProxySidecar(pod *k8sv1.Pod, proxyImage string, consolePort int, vncPort int) {
+	// Find the existing "private" volume used by compute for /var/run/kubevirt-private
+	privateVolName := "private"
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "private" {
+			privateVolName = v.Name
+			break
+		}
+	}
+
+	// Add combined access proxy as a sidecar, sharing the same private volume as compute
+	// This sidecar will handle both serial console and VNC access
+	pod.Spec.Containers = append(pod.Spec.Containers, k8sv1.Container{
+		Name:    "access-proxy",
+		Image:   proxyImage,
+		Command: []string{"/console-proxy", fmt.Sprintf("-port=%d", consolePort), "-listen=unix"},
+		Ports: []k8sv1.ContainerPort{
+			{Name: "console", ContainerPort: int32(consolePort), Protocol: k8sv1.ProtocolTCP},
+			{Name: "vnc", ContainerPort: int32(vncPort), Protocol: k8sv1.ProtocolTCP},
+		},
 		VolumeMounts: []k8sv1.VolumeMount{
 			{Name: privateVolName, MountPath: "/var/run/kubevirt-private"},
 		},

--- a/pkg/transformer/transformer_test.go
+++ b/pkg/transformer/transformer_test.go
@@ -394,3 +394,274 @@ spec:
 		require.Nil(t, vmi.Spec.Domain.Devices.Interfaces[0].PasstBinding, "Should not have Passt binding")
 	})
 }
+
+func TestTransformWithAccessProxies(t *testing.T) {
+	t.Run("access proxies enabled by default", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+
+		tmpFile, err := os.CreateTemp("", "vm.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		transformer := NewVMToPodTransformer(WithAddAccessProxies(true, "test-proxy-image", 28080, 15900))
+		pod, err := transformer.Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		// Should have compute + access-proxy containers
+		require.Len(t, pod.Spec.Containers, 2)
+
+		// Find access-proxy container
+		var proxyContainer k8sv1.Container
+		found := false
+		for _, c := range pod.Spec.Containers {
+			if c.Name == "access-proxy" {
+				proxyContainer = c
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "access-proxy container should be present")
+		require.Equal(t, "test-proxy-image", proxyContainer.Image)
+
+		// Check containerPorts
+		require.Len(t, proxyContainer.Ports, 2, "Should have 2 containerPort entries")
+		require.Equal(t, "console", proxyContainer.Ports[0].Name)
+		require.Equal(t, int32(28080), proxyContainer.Ports[0].ContainerPort)
+		require.Equal(t, k8sv1.ProtocolTCP, proxyContainer.Ports[0].Protocol)
+		require.Equal(t, "vnc", proxyContainer.Ports[1].Name)
+		require.Equal(t, int32(15900), proxyContainer.Ports[1].ContainerPort)
+		require.Equal(t, k8sv1.ProtocolTCP, proxyContainer.Ports[1].Protocol)
+
+		// Check no hostPort
+		require.Equal(t, int32(0), proxyContainer.Ports[0].HostPort, "Should not have HostPort")
+		require.Equal(t, int32(0), proxyContainer.Ports[1].HostPort, "Should not have HostPort")
+
+		// Check warning annotation
+		require.NotNil(t, pod.Annotations)
+		annotation, ok := pod.Annotations["kubevirt-vm-to-pod/proxy-ports"]
+		require.True(t, ok, "Should have proxy-ports annotation")
+		require.Contains(t, annotation, "28080")
+		require.Contains(t, annotation, "15900")
+	})
+
+	t.Run("custom ports are respected", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+
+		tmpFile, err := os.CreateTemp("", "vm.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		transformer := NewVMToPodTransformer(WithAddAccessProxies(true, "test-proxy-image", 9999, 5901))
+		pod, err := transformer.Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		// Find access-proxy container
+		var proxyContainer k8sv1.Container
+		for _, c := range pod.Spec.Containers {
+			if c.Name == "access-proxy" {
+				proxyContainer = c
+				break
+			}
+		}
+
+		require.Len(t, proxyContainer.Ports, 2)
+		require.Equal(t, int32(9999), proxyContainer.Ports[0].ContainerPort)
+		require.Equal(t, int32(5901), proxyContainer.Ports[1].ContainerPort)
+
+		// Check annotation contains custom ports
+		annotation := pod.Annotations["kubevirt-vm-to-pod/proxy-ports"]
+		require.Contains(t, annotation, "9999")
+		require.Contains(t, annotation, "5901")
+	})
+
+	t.Run("access proxies disabled", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+
+		tmpFile, err := os.CreateTemp("", "vm.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		transformer := NewVMToPodTransformer(WithAddAccessProxies(false, "", 28080, 15900))
+		pod, err := transformer.Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		// Should only have compute container
+		require.Len(t, pod.Spec.Containers, 1)
+		require.Equal(t, "compute", pod.Spec.Containers[0].Name)
+
+		// No proxy annotation
+		_, hasAnnotation := pod.Annotations["kubevirt-vm-to-pod/proxy-ports"]
+		require.False(t, hasAnnotation, "Should not have proxy-ports annotation when disabled")
+	})
+
+	t.Run("no hostPort on proxy container", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+
+		tmpFile, err := os.CreateTemp("", "vm.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		transformer := NewVMToPodTransformer(WithAddAccessProxies(true, "test-proxy-image", 28080, 15900))
+		pod, err := transformer.Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		// Find access-proxy container and verify no hostPort
+		for _, c := range pod.Spec.Containers {
+			if c.Name == "access-proxy" {
+				for _, port := range c.Ports {
+					require.Equal(t, int32(0), port.HostPort, "Port %s should not have HostPort", port.Name)
+				}
+			}
+		}
+	})
+
+	t.Run("shared volume mounted in both containers", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+
+		tmpFile, err := os.CreateTemp("", "vm.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		transformer := NewVMToPodTransformer(WithAddAccessProxies(true, "test-proxy-image", 28080, 15900))
+		pod, err := transformer.Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		// Find the private volume
+		privateVolumeName := ""
+		for _, v := range pod.Spec.Volumes {
+			if v.Name == "private" {
+				privateVolumeName = v.Name
+				break
+			}
+		}
+		require.NotEmpty(t, privateVolumeName, "private volume should exist")
+
+		// Verify both containers mount it
+		computeMountsPrivate := false
+		proxyMountsPrivate := false
+
+		for _, c := range pod.Spec.Containers {
+			for _, mount := range c.VolumeMounts {
+				if mount.Name == privateVolumeName {
+					if c.Name == "compute" {
+						computeMountsPrivate = true
+					}
+					if c.Name == "access-proxy" {
+						proxyMountsPrivate = true
+					}
+				}
+			}
+		}
+
+		require.True(t, computeMountsPrivate, "compute container should mount private volume")
+		require.True(t, proxyMountsPrivate, "access-proxy container should mount private volume")
+	})
+
+	t.Run("backward compat: legacy console proxy still works", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+
+		tmpFile, err := os.CreateTemp("", "vm.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+		tmpFile.Close()
+
+		// Use legacy WithAddConsoleProxy
+		transformer := NewVMToPodTransformer(WithAddConsoleProxy(true, "test-proxy-image", 8080))
+		pod, err := transformer.Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		// Should have console-proxy container (not access-proxy)
+		require.Len(t, pod.Spec.Containers, 2)
+		found := false
+		for _, c := range pod.Spec.Containers {
+			if c.Name == "console-proxy" {
+				found = true
+			}
+			require.NotEqual(t, "access-proxy", c.Name, "Should not have access-proxy when using legacy path")
+		}
+		require.True(t, found, "Should have console-proxy container")
+	})
+}

--- a/tests/functional/run-console-proxy-test.sh
+++ b/tests/functional/run-console-proxy-test.sh
@@ -14,7 +14,7 @@ VM_FILE="$TEST_DIR/test-vm.yaml"
 POD_YAML="$TEST_DIR/test-pod-with-proxy.yaml"
 BINARY="$REPO_ROOT/kubevirt-vm-to-pod"
 POD_NAME="virt-launcher-cirros-test"
-PROXY_PORT=8080
+PROXY_PORT=28080
 TEST_TIMEOUT=180
 
 echo_success() { echo -e "${GREEN}✓${NC} $1"; }
@@ -48,10 +48,10 @@ if [ ! -f "$BINARY" ]; then
     echo_success "Binary built successfully"
 fi
 
-# Step 2: Generate Pod YAML with console proxy, force-passt, and device mounting
-echo_info "Generating Pod YAML with console proxy, force-passt, and device mounting..."
+# Step 2: Generate Pod YAML with access proxy (default) and device mounting
+echo_info "Generating Pod YAML with access proxy and device mounting..."
 cd "$REPO_ROOT"
-"$BINARY" --vm-file="$VM_FILE" --add-console-proxy --force-passt --mount-devices > "$POD_YAML"
+"$BINARY" --vm-file="$VM_FILE" --mount-devices > "$POD_YAML"
 
 if [ ! -s "$POD_YAML" ]; then
     echo_error "Failed to generate Pod YAML"
@@ -110,7 +110,7 @@ fi
 # Step 5: Verify both containers
 echo_info "Verifying containers..."
 COMPUTE_CONTAINER=$(podman ps --filter "pod=$POD_NAME" --filter "name=.*compute" --format "{{.Names}}" | head -1)
-PROXY_CONTAINER=$(podman ps --filter "pod=$POD_NAME" --filter "name=.*console-proxy" --format "{{.Names}}" | head -1)
+PROXY_CONTAINER=$(podman ps --filter "pod=$POD_NAME" --filter "name=.*access-proxy" --format "{{.Names}}" | head -1)
 
 if [ -z "$COMPUTE_CONTAINER" ]; then
     echo_error "Compute container not found"
@@ -119,10 +119,10 @@ fi
 echo_success "Compute container: $COMPUTE_CONTAINER"
 
 if [ -z "$PROXY_CONTAINER" ]; then
-    echo_error "Console proxy container not found"
+    echo_error "Access proxy container not found"
     exit 1
 fi
-echo_success "Console proxy container: $PROXY_CONTAINER"
+echo_success "Access proxy container: $PROXY_CONTAINER"
 
 # Step 6: Check console proxy is listening
 echo_info "Checking console proxy port..."

--- a/tests/functional/run-quick-test.sh
+++ b/tests/functional/run-quick-test.sh
@@ -88,9 +88,9 @@ else
     echo_info "Podman dry-run validation skipped (may not be supported)"
 fi
 
-# Step 5: Test with force-passt
-echo_info "Test 4: Generate Pod with --force-passt..."
-"$BINARY" --vm-file="$VM_FILE" --force-passt > "$POD_YAML"
+# Step 5: Test with passt (default behavior, no flag needed)
+echo_info "Test 4: Generate Pod with passt networking (default)..."
+"$BINARY" --vm-file="$VM_FILE" > "$POD_YAML"
 
 if python3 -c "
 import yaml, json, sys
@@ -151,22 +151,52 @@ else
     echo_info "GPU device mount check skipped (GPU not in test VM)"
 fi
 
-# Step 7: Test with console proxy
-echo_info "Test 6: Generate Pod with --add-console-proxy..."
-"$BINARY" --vm-file="$VM_FILE" --add-console-proxy > "$POD_YAML"
+# Step 7: Test with access proxy (default behavior)
+echo_info "Test 6: Generate Pod with default access proxies..."
+"$BINARY" --vm-file="$VM_FILE" > "$POD_YAML"
 
-if grep -q "console-proxy" "$POD_YAML"; then
-    echo_success "Console proxy sidecar present"
+if grep -q "access-proxy" "$POD_YAML"; then
+    echo_success "Access proxy sidecar present by default"
 else
-    echo_error "Console proxy sidecar missing"
+    echo_error "Access proxy sidecar missing"
+    exit 1
+fi
+
+# Step 7b: Test disabling access proxies
+echo_info "Test 6b: Generate Pod with --add-access-proxies=false..."
+"$BINARY" --vm-file="$VM_FILE" --add-access-proxies=false > "$POD_YAML"
+
+if grep -q "access-proxy" "$POD_YAML"; then
+    echo_error "Access proxy sidecar should not be present when disabled"
+    exit 1
+fi
+echo_success "Access proxy correctly disabled"
+
+# Step 7c: Test custom proxy ports
+echo_info "Test 6c: Generate Pod with custom proxy ports..."
+"$BINARY" --vm-file="$VM_FILE" --proxy-port=9999 --vnc-proxy-port=5901 > "$POD_YAML"
+
+if grep -q "9999" "$POD_YAML" && grep -q "5901" "$POD_YAML"; then
+    echo_success "Custom proxy ports applied"
+else
+    echo_error "Custom proxy ports not found"
+    exit 1
+fi
+
+# Step 7d: Verify no hostPort
+echo_info "Test 6d: Verify no hostPort in proxy container..."
+if ! grep -q "hostPort" "$POD_YAML"; then
+    echo_success "No hostPort present in proxy container"
+else
+    echo_error "Unexpected hostPort found in proxy container"
     exit 1
 fi
 
 # Step 8: Test combined flags
-echo_info "Test 7: Generate Pod with all flags..."
-"$BINARY" --vm-file="$VM_FILE" --add-console-proxy --force-passt --mount-devices > "$POD_YAML"
+echo_info "Test 7: Generate Pod with combined flags..."
+"$BINARY" --vm-file="$VM_FILE" --mount-devices > "$POD_YAML"
 
-if grep -q "console-proxy" "$POD_YAML" && grep -q '"passt"' "$POD_YAML" && grep -q "/dev/kvm" "$POD_YAML"; then
+if grep -q "access-proxy" "$POD_YAML" && grep -q "/dev/kvm" "$POD_YAML"; then
     echo_success "All combined flags work correctly"
 else
     echo_error "Combined flags failed"
@@ -185,9 +215,12 @@ echo "  ✓ Pod YAML structure validation"
 echo "  ✓ Pod name (not generateName)"
 echo "  ✓ virt-launcher container"
 echo "  ✓ STANDALONE_VMI env var"
-echo "  ✓ --force-passt flag"
+echo "  ✓ Passt networking (default)"
 echo "  ✓ --mount-devices flag"
-echo "  ✓ --add-console-proxy flag"
+echo "  ✓ Access proxy (default enabled)"
+echo "  ✓ --add-access-proxies=false"
+echo "  ✓ Custom proxy ports"
+echo "  ✓ No hostPort in proxy"
 echo "  ✓ All combined flags"
 echo ""
 echo_info "To run full functional test with podman kube play:"


### PR DESCRIPTION
## Summary                                                                                             
                                                                                                          
   This PR makes access proxies the default behavior and adds configurable ports for both console and VNC access.

   ### Key Changes                                                                                                                                                                                                 

   - **New flag `--add-access-proxies`** (default: `true`) — replaces `--add-console-proxy` as the primary mechanism
   - **New flag `--vnc-proxy-port`** (default: `15900`) — configures VNC proxy port
   - **Updated `--proxy-port`** default from `8080` to `28080` — new default console port                                                                                                                          
   - **Combined proxy sidecar** — single `access-proxy` container with ports for both console and VNC
   - **No `hostPort`** — only `containerPort` entries (users must use `podman kube play -p`)
   - **Warning annotation** — `kubevirt-vm-to-pod/proxy-ports` with guidance on port publishing
   - **Backward compatibility** — `--add-console-proxy` still works (deprecated with warning)         