### PR TITLE
feat: DataVolume error improvements and persistence warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Convert KubeVirt VirtualMachine definitions into standalone Pods that can run ou
 - ✅ Converts VM to standalone Pod YAML
 - ✅ Supports Instancetype and Preference expansion
 - ✅ Optional console proxy sidecar for VM access
+- ✅ PVC and hostDisk volume support for persistent storage
 - ✅ Passt network binding by default for standalone execution
 - ✅ Mount KVM devices for hardware virtualization
 - ✅ Compatible with Podman kube play
@@ -229,6 +230,42 @@ curl http://localhost:8080/console
 # Or use VNC/serial console clients
 ```
 
+### Volume Support
+
+The tool supports several KubeVirt volume types for standalone execution:
+
+| Volume Type | Standalone Behavior | Notes |
+|-------------|-------------------|-------|
+| `containerDisk` | ✅ Works as-is | Pulled as a container image |
+| `cloudInitNoCloud` | ✅ Works as-is | Inline user-data supported |
+| `cloudInitConfigDrive` | ✅ Works as-is | Inline user-data supported |
+| `persistentVolumeClaim` | ✅ Podman named volume | Data persists on this host only |
+| `hostDisk` | ✅ Host filesystem path | Translated to hostPath mount |
+| `dataVolume` | ❌ Not supported | Requires CDI controller — use hostDisk or PVC instead |
+| `configMap` / `secret` | ❌ Not supported | Use cloudInit with inline data instead |
+
+**Persistent storage example (PVC):**
+```yaml
+volumes:
+- persistentVolumeClaim:
+    claimName: my-vm-data
+  name: datadisk
+```
+In standalone mode, this becomes a Podman named volume. Data persists across pod restarts on the same host but does not transfer to other machines.
+
+**Persistent storage example (hostDisk):**
+```yaml
+volumes:
+- hostDisk:
+    path: /var/lib/vms/disk.img
+    type: DiskOrCreate
+    capacity: 10Gi
+  name: datadisk
+```
+The disk image file is accessed directly on the host filesystem. With `DiskOrCreate`, it will be created if it doesn't exist.
+
+**Persistence warnings:** When PVC or hostDisk volumes are present, the generated Pod includes a `kubevirt-vm-to-pod/persistence-warning` annotation explaining the standalone persistence semantics.
+
 ## Sample VirtualMachine YAML
 
 ```yaml
@@ -337,8 +374,9 @@ DEV_MODE=true make podman-build-dev
 4. **Generate VMI** - Creates VirtualMachineInstance from VM template
 5. **Render Pod** - Uses KubeVirt's TemplateService to create Pod spec
 6. **Apply Options** - Adds console proxy, device mounts, networking changes
-7. **Embed VMI** - Injects VMI JSON into STANDALONE_VMI env var
-8. **Output** - Generates final Pod YAML
+7. **Add Warnings** - Annotates persistence semantics for PVC/hostDisk volumes
+8. **Embed VMI** - Injects VMI JSON into STANDALONE_VMI env var
+9. **Output** - Generates final Pod YAML
 
 The generated Pod contains:
 - **compute container**: virt-launcher running the VM
@@ -385,6 +423,8 @@ VirtualMachine YAML
 
 - **No live migration**: Pods are standalone and don't support migration
 - **No KubeVirt controllers**: No automatic reconciliation or state management
+- **No DataVolumes**: DataVolume volumes require the CDI controller — use hostDisk or PVC instead
+- **PVC locality**: PVC volumes become local Podman named volumes, not portable across hosts
 - **Limited networking**: Best with pod networking or Passt binding
 - **Device access**: Requires `/dev/kvm` access on host for hardware virtualization
 - **Dedicated CPUs**: VMs with `dedicatedCpuPlacement` need manual CPU pinning via container runtime (e.g., `podman run --cpuset-cpus`)

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -224,6 +224,9 @@ func (t *VMToPodTransformer) transformBytes(data []byte) (*k8sv1.Pod, error) {
 
 	cleanupForStandalone(pod, vmi)
 
+	// Add persistence warning annotations for volumes that require special setup
+	addPersistenceWarnings(pod, vm)
+
 	// Populate VMI interface status with PodInterfaceName.
 	// In Kubernetes, virt-handler sets this; for standalone mode we must do it ourselves.
 	populateInterfaceStatus(vmi)
@@ -474,7 +477,9 @@ func validateForStandalone(vm *virtv1.VirtualMachine) error {
 		if vol.DataVolume != nil {
 			errors = append(errors, fmt.Sprintf(
 				"volume %q uses DataVolume which requires the CDI controller. "+
-					"Pre-download the image and use a containerDisk instead", vol.Name))
+					"Recommended alternatives for standalone mode:\n"+
+					"    - Use hostDisk (for local disk images on the host filesystem)\n"+
+					"    - Use persistentVolumeClaim (becomes a Podman named volume)", vol.Name))
 		}
 		if vol.ConfigMap != nil {
 			errors = append(errors, fmt.Sprintf(
@@ -590,6 +595,43 @@ func cleanupForStandalone(pod *k8sv1.Pod, vmi *virtv1.VirtualMachineInstance) {
 		}
 	}
 	pod.Spec.InitContainers = keptInit
+}
+
+func addPersistenceWarnings(pod *k8sv1.Pod, vm *virtv1.VirtualMachine) {
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+
+	spec := vm.Spec.Template.Spec
+	var warnings []string
+
+	// Check for PVC volumes
+	hasPVC := false
+	for _, vol := range spec.Volumes {
+		if vol.PersistentVolumeClaim != nil {
+			hasPVC = true
+			break
+		}
+	}
+	if hasPVC {
+		warnings = append(warnings, "PVC volumes: In standalone mode, persistentVolumeClaim volumes become local Podman named volumes. They persist across pod restarts on THIS host only, but will NOT survive if you move the Pod to another machine or reinstall Podman.")
+	}
+
+	// Check for hostDisk volumes
+	hasHostDisk := false
+	for _, vol := range spec.Volumes {
+		if vol.HostDisk != nil {
+			hasHostDisk = true
+			break
+		}
+	}
+	if hasHostDisk {
+		warnings = append(warnings, "hostDisk volumes: The specified disk image files must exist on the host filesystem at the paths defined in the VM spec. For DiskOrCreate type, the file will be created if missing.")
+	}
+
+	if len(warnings) > 0 {
+		pod.Annotations["kubevirt-vm-to-pod/persistence-warning"] = strings.Join(warnings, " | ")
+	}
 }
 
 var codec = serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer()

--- a/pkg/transformer/transformer_test.go
+++ b/pkg/transformer/transformer_test.go
@@ -498,3 +498,184 @@ spec:
 		require.Nil(t, vmi.Spec.Domain.Devices.Interfaces[0].PasstBinding, "Should not have Passt binding")
 	})
 }
+
+func TestDataVolumeError(t *testing.T) {
+	t.Run("DataVolume volume produces clear error with alternatives", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm-datavolume
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: datadisk
+      volumes:
+      - dataVolume:
+          name: test-dv
+        name: datadisk
+`)
+		tmpFile, err := os.CreateTemp("", "vm-datavolume.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+
+		_, err = NewVMToPodTransformer().Transform(tmpFile.Name())
+		require.Error(t, err, "Should fail with DataVolume error")
+		require.Contains(t, err.Error(), "DataVolume")
+		require.Contains(t, err.Error(), "hostDisk")
+		require.Contains(t, err.Error(), "persistentVolumeClaim")
+		require.Contains(t, err.Error(), "Recommended alternatives")
+	})
+}
+
+func TestPersistenceWarnings(t *testing.T) {
+	t.Run("PVC volume adds persistence warning annotation", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm-pvc
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: datadisk
+      volumes:
+      - persistentVolumeClaim:
+          claimName: test-vm-data
+        name: datadisk
+`)
+		tmpFile, err := os.CreateTemp("", "vm-pvc-warning.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+
+		pod, err := NewVMToPodTransformer().Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		warning, ok := pod.Annotations["kubevirt-vm-to-pod/persistence-warning"]
+		require.True(t, ok, "Should have persistence warning annotation")
+		require.Contains(t, warning, "PVC volumes")
+		require.Contains(t, warning, "Podman named volumes")
+		require.Contains(t, warning, "THIS host only")
+	})
+
+	t.Run("hostDisk volume adds persistence warning annotation", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm-hostdisk
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: hostdisk
+      volumes:
+      - hostDisk:
+          path: /var/lib/vms/disk.img
+          type: DiskOrCreate
+          capacity: 1Gi
+        name: hostdisk
+`)
+		tmpFile, err := os.CreateTemp("", "vm-hostdisk-warning.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+
+		pod, err := NewVMToPodTransformer().Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		warning, ok := pod.Annotations["kubevirt-vm-to-pod/persistence-warning"]
+		require.True(t, ok, "Should have persistence warning annotation")
+		require.Contains(t, warning, "hostDisk volumes")
+		require.Contains(t, warning, "exist on the host filesystem")
+		require.Contains(t, warning, "DiskOrCreate")
+	})
+
+	t.Run("VM with both PVC and hostDisk adds combined warning", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm-both
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: pvc-disk
+          - disk:
+              bus: virtio
+            name: host-disk
+      volumes:
+      - persistentVolumeClaim:
+          claimName: test-pvc
+        name: pvc-disk
+      - hostDisk:
+          path: /data/disk.img
+          type: Disk
+        name: host-disk
+`)
+		tmpFile, err := os.CreateTemp("", "vm-both.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+
+		pod, err := NewVMToPodTransformer().Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		warning, ok := pod.Annotations["kubevirt-vm-to-pod/persistence-warning"]
+		require.True(t, ok, "Should have persistence warning annotation")
+		require.Contains(t, warning, "PVC volumes")
+		require.Contains(t, warning, "hostDisk volumes")
+		require.Contains(t, warning, "|") // Separator between warnings
+	})
+
+	t.Run("VM without persistent volumes has no warning annotation", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm-ephemeral
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+		tmpFile, err := os.CreateTemp("", "vm-ephemeral.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+
+		pod, err := NewVMToPodTransformer().Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		_, ok := pod.Annotations["kubevirt-vm-to-pod/persistence-warning"]
+		require.False(t, ok, "Should not have persistence warning annotation for ephemeral VM")
+	})
+}


### PR DESCRIPTION
## Summary
- Improved DataVolume error message in `validateForStandalone()` to suggest `hostDisk` and `persistentVolumeClaim` as alternatives (instead of only `containerDisk`)
- Added `kubevirt-vm-to-pod/persistence-warning` annotation to generated pods when PVC or hostDisk volumes are present, explaining standalone persistence semantics
- Added 5 unit tests covering DataVolume error, PVC warning, hostDisk warning, combined warnings, and no-warning for ephemeral VMs

## Context
Builds on PR #14 which added PVC and hostDisk volume support. This PR improves the user experience by providing actionable error messages and clear warnings about standalone persistence behavior.

## Test plan
- [x] `go test ./pkg/transformer/...` — all tests pass (including 5 new tests)
- [x] `go build ./...` — clean compilation
- [ ] Generate Pod from VM with DataVolume → verify error message suggests hostDisk and PVC alternatives
- [ ] Generate Pod from VM with PVC → verify `kubevirt-vm-to-pod/persistence-warning` annotation present
- [ ] Generate Pod from VM with hostDisk → verify annotation mentions host filesystem requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)