### PR TITLE
feat: add Quadlet output for systemd-managed VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Convert KubeVirt VirtualMachine definitions into standalone Pods that can run ou
 - ✅ PVC and hostDisk volume support for persistent storage
 - ✅ Passt network binding by default for standalone execution
 - ✅ Mount KVM devices for hardware virtualization
+- ✅ Quadlet output for systemd-managed VMs
 - ✅ Compatible with Podman kube play
 - ✅ Uses KubeVirt v1.8.0 APIs
 
@@ -88,7 +89,8 @@ podman kube play pod.yaml
 | `--preference-file` | Path to VirtualMachinePreference YAML file (optional) | - |
 | `--proxy-image` | Console proxy container image | `quay.io/vladikr/kubevirt-console-proxy:latest` |
 | `--proxy-port` | Port for console proxy to listen on | `8080` |
-| `--output` | Output format: yaml or json | `yaml` |
+| `--output` | Output format: yaml, json, or quadlet | `yaml` |
+| `--quadlet-dir` | Directory to write Quadlet files to (used with `--output=quadlet`) | `.` |
 
 ## Usage Examples
 
@@ -265,6 +267,35 @@ volumes:
 The disk image file is accessed directly on the host filesystem. With `DiskOrCreate`, it will be created if it doesn't exist.
 
 **Persistence warnings:** When PVC or hostDisk volumes are present, the generated Pod includes a `kubevirt-vm-to-pod/persistence-warning` annotation explaining the standalone persistence semantics.
+
+### Quadlet Output (`--output=quadlet`)
+
+Generates Podman Quadlet files for running the VM as a systemd service — the recommended way to manage persistent containerized workloads with Podman.
+
+```bash
+./kubevirt-vm-to-pod myvm.yaml --output=quadlet --quadlet-dir=./output/
+```
+
+This produces two files:
+- `<vm-name>-pod.yaml` — the Pod YAML
+- `<vm-name>.kube` — the Quadlet unit file referencing the Pod YAML
+
+**Install as a user systemd service:**
+```bash
+mkdir -p ~/.config/containers/systemd
+cp ./output/*-pod.yaml ./output/*.kube ~/.config/containers/systemd/
+systemctl --user daemon-reload
+systemctl --user start <vm-name>
+```
+
+The VM will start automatically on login and restart on failure. Use `systemctl --user stop <vm-name>` to stop it.
+
+**For system-wide services** (runs at boot, no login required):
+```bash
+sudo cp ./output/*-pod.yaml ./output/*.kube /etc/containers/systemd/
+sudo systemctl daemon-reload
+sudo systemctl start <vm-name>
+```
 
 ## Sample VirtualMachine YAML
 

--- a/cmd/vmToPod.go
+++ b/cmd/vmToPod.go
@@ -10,11 +10,14 @@ import (
 	"os/signal"
 	"syscall"
 
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	k8sv1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/vladikr/kubevirt-vm-to-pod/pkg/quadlet"
 	"github.com/vladikr/kubevirt-vm-to-pod/pkg/transformer"
 )
 
@@ -29,6 +32,7 @@ var (
 	proxyPort        int
 	noPasst          bool
 	mountDevices     bool
+	quadletDir       string
 )
 
 func main() {
@@ -51,8 +55,8 @@ or piped through stdin:
 				vmFile = args[0]
 			}
 
-			if output != "yaml" && output != "json" {
-				return fmt.Errorf("output must be 'yaml' or 'json'")
+			if output != "yaml" && output != "json" && output != "quadlet" {
+				return fmt.Errorf("output must be 'yaml', 'json', or 'quadlet'")
 			}
 			if launcherImage == "" {
 				launcherImage = "quay.io/kubevirt/virt-launcher:v1.8.0"
@@ -81,6 +85,10 @@ or piped through stdin:
 				return fmt.Errorf("failed to transform VM to Pod: %v", err)
 			}
 
+			if output == "quadlet" {
+				return writeQuadletFiles(pod, quadletDir)
+			}
+
 			var outputBytes []byte
 			if output == "yaml" {
 				outputBytes, err = yaml.Marshal(pod)
@@ -106,6 +114,7 @@ or piped through stdin:
 	rootCmd.Flags().IntVar(&proxyPort, "proxy-port", 8080, "Port for the console proxy to listen on")
 	rootCmd.Flags().BoolVar(&noPasst, "no-passt", false, "Preserve original network bindings instead of converting to Passt (requires CNI plugins)")
 	rootCmd.Flags().BoolVar(&mountDevices, "mount-devices", true, "Mount KVM devices (/dev/kvm, /dev/vhost-net, /dev/net/tun) for standalone execution")
+	rootCmd.Flags().StringVar(&quadletDir, "quadlet-dir", ".", "Directory to write Quadlet files to (used with --output=quadlet)")
 
 	consoleCmd := &cobra.Command{
 		Use:   "console <vm-name>",
@@ -158,6 +167,42 @@ or piped through stdin:
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func writeQuadletFiles(pod *k8sv1.Pod, dir string) error {
+	vmName := pod.Name
+	if vmName == "" {
+		vmName = "kubevirt-vm"
+	}
+
+	podYAMLFilename := vmName + "-pod.yaml"
+	kubeFilename := vmName + ".kube"
+
+	podYAMLBytes, err := yaml.Marshal(pod)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Pod: %v", err)
+	}
+
+	podYAMLPath := filepath.Join(dir, podYAMLFilename)
+	if err := os.WriteFile(podYAMLPath, podYAMLBytes, 0644); err != nil {
+		return fmt.Errorf("failed to write Pod YAML: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "Wrote %s\n", podYAMLPath)
+
+	kubeContent := quadlet.Generate(pod, podYAMLFilename)
+	kubePath := filepath.Join(dir, kubeFilename)
+	if err := os.WriteFile(kubePath, []byte(kubeContent), 0644); err != nil {
+		return fmt.Errorf("failed to write Quadlet file: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "Wrote %s\n", kubePath)
+
+	fmt.Fprintf(os.Stderr, "\nTo install as a user systemd service:\n")
+	fmt.Fprintf(os.Stderr, "  mkdir -p ~/.config/containers/systemd\n")
+	fmt.Fprintf(os.Stderr, "  cp %s %s ~/.config/containers/systemd/\n", podYAMLPath, kubePath)
+	fmt.Fprintf(os.Stderr, "  systemctl --user daemon-reload\n")
+	fmt.Fprintf(os.Stderr, "  systemctl --user start %s\n", vmName)
+
+	return nil
 }
 
 func runAttach(socketPath string) error {

--- a/pkg/quadlet/quadlet.go
+++ b/pkg/quadlet/quadlet.go
@@ -1,0 +1,41 @@
+package quadlet
+
+import (
+	"fmt"
+	"strings"
+
+	k8sv1 "k8s.io/api/core/v1"
+)
+
+func Generate(pod *k8sv1.Pod, yamlFilename string) string {
+	vmName := pod.Name
+	if vmName == "" {
+		vmName = "kubevirt-vm"
+	}
+
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "[Unit]\n")
+	fmt.Fprintf(&b, "Description=KubeVirt VM: %s\n", vmName)
+	fmt.Fprintf(&b, "After=network-online.target\n")
+
+	fmt.Fprintf(&b, "\n[Kube]\n")
+	fmt.Fprintf(&b, "Yaml=%s\n", yamlFilename)
+
+	for _, c := range pod.Spec.Containers {
+		for _, p := range c.Ports {
+			if p.ContainerPort != 0 {
+				fmt.Fprintf(&b, "PublishPort=%d:%d\n", p.ContainerPort, p.ContainerPort)
+			}
+		}
+	}
+
+	fmt.Fprintf(&b, "\n[Service]\n")
+	fmt.Fprintf(&b, "Restart=always\n")
+	fmt.Fprintf(&b, "TimeoutStartSec=900\n")
+
+	fmt.Fprintf(&b, "\n[Install]\n")
+	fmt.Fprintf(&b, "WantedBy=default.target\n")
+
+	return b.String()
+}

--- a/pkg/quadlet/quadlet_test.go
+++ b/pkg/quadlet/quadlet_test.go
@@ -1,0 +1,85 @@
+package quadlet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGenerate(t *testing.T) {
+	t.Run("basic pod produces valid quadlet", func(t *testing.T) {
+		pod := &k8sv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "virt-launcher-myvm",
+			},
+		}
+
+		result := Generate(pod, "virt-launcher-myvm-pod.yaml")
+
+		require.Contains(t, result, "[Unit]")
+		require.Contains(t, result, "Description=KubeVirt VM: virt-launcher-myvm")
+		require.Contains(t, result, "After=network-online.target")
+
+		require.Contains(t, result, "[Kube]")
+		require.Contains(t, result, "Yaml=virt-launcher-myvm-pod.yaml")
+
+		require.Contains(t, result, "[Service]")
+		require.Contains(t, result, "Restart=always")
+		require.Contains(t, result, "TimeoutStartSec=900")
+
+		require.Contains(t, result, "[Install]")
+		require.Contains(t, result, "WantedBy=default.target")
+	})
+
+	t.Run("pod with container ports publishes them", func(t *testing.T) {
+		pod := &k8sv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "virt-launcher-myvm",
+			},
+			Spec: k8sv1.PodSpec{
+				Containers: []k8sv1.Container{
+					{
+						Name: "console-proxy",
+						Ports: []k8sv1.ContainerPort{
+							{ContainerPort: 8080},
+							{ContainerPort: 15900},
+						},
+					},
+				},
+			},
+		}
+
+		result := Generate(pod, "myvm-pod.yaml")
+
+		require.Contains(t, result, "PublishPort=8080:8080")
+		require.Contains(t, result, "PublishPort=15900:15900")
+	})
+
+	t.Run("pod without name uses fallback", func(t *testing.T) {
+		pod := &k8sv1.Pod{}
+
+		result := Generate(pod, "pod.yaml")
+
+		require.Contains(t, result, "Description=KubeVirt VM: kubevirt-vm")
+	})
+
+	t.Run("sections are in correct order", func(t *testing.T) {
+		pod := &k8sv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vm"},
+		}
+
+		result := Generate(pod, "test-vm-pod.yaml")
+
+		unitIdx := strings.Index(result, "[Unit]")
+		kubeIdx := strings.Index(result, "[Kube]")
+		serviceIdx := strings.Index(result, "[Service]")
+		installIdx := strings.Index(result, "[Install]")
+
+		require.True(t, unitIdx < kubeIdx, "[Unit] should come before [Kube]")
+		require.True(t, kubeIdx < serviceIdx, "[Kube] should come before [Service]")
+		require.True(t, serviceIdx < installIdx, "[Service] should come before [Install]")
+	})
+}


### PR DESCRIPTION
## Summary
- New `--output=quadlet` option generates Podman Quadlet files (`.kube` + Pod YAML)
- Users can install both files into `~/.config/containers/systemd/` to run VMs as systemd services
- Automatic restart on failure, starts on login (user) or boot (system)
- New `--quadlet-dir` flag to control output directory (default: current directory)
- New `pkg/quadlet` package with `Generate()` function and unit tests

## Example
```bash
./kubevirt-vm-to-pod myvm.yaml --output=quadlet --quadlet-dir=./output/
# Produces: output/virt-launcher-myvm-pod.yaml + output/virt-launcher-myvm.kube

cp ./output/* ~/.config/containers/systemd/
systemctl --user daemon-reload
systemctl --user start virt-launcher-myvm
```

## Test plan
- [x] `go test ./...` — all tests pass (4 new quadlet tests)
- [x] `go build ./...` — clean compilation
- [ ] Run `--output=quadlet` and inspect generated `.kube` file format
- [ ] Copy files to `~/.config/containers/systemd/` and verify `systemctl --user daemon-reload` picks them up

🤖 Generated with [Claude Code](https://claude.com/claude-code)