### PR TITLE
feat: expose KubeVirt notify socket for VM event monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ podman kube play pod.yaml
 | `--preference-file` | Path to VirtualMachinePreference YAML file (optional) | - |
 | `--proxy-image` | Console proxy container image | `quay.io/vladikr/kubevirt-console-proxy:latest` |
 | `--proxy-port` | Port for console proxy to listen on | `8080` |
+| `--notify-socket-dir` | Host directory to expose KubeVirt notify socket for VM event monitoring | - |
 | `--output` | Output format: yaml or json | `yaml` |
 
 ## Usage Examples
@@ -228,6 +229,49 @@ Adds a console proxy sidecar container for accessing the VM console.
 # After starting the Pod
 curl http://localhost:8080/console
 # Or use VNC/serial console clients
+```
+
+### VM Event Monitoring (`--notify-socket-dir`)
+
+Exposes the KubeVirt domain notify socket on the host, allowing an external monitoring service to receive VM lifecycle events (started, stopped, crashed, paused, etc.) in real time via gRPC.
+
+```bash
+./kubevirt-vm-to-pod myvm.yaml --notify-socket-dir=/tmp/notify/myvm > pod.yaml
+```
+
+Virt-launcher inside the container connects to `domain-notify-pipe.sock` in this directory and sends events as they happen. Your monitoring service listens on that socket before starting the pod.
+
+**Protocol details:**
+
+The notify socket uses gRPC with two services:
+
+1. **Version negotiation** — `NotifyInfo.Info()` returns `{supportedNotifyVersions: [1]}`
+2. **Event handling** — `Notify.HandleDomainEvent(DomainEventRequest)` receives:
+   - `eventType`: `"Added"`, `"Modified"`, `"Deleted"`, or `"Error"`
+   - `domainJSON`: VM domain state as JSON (includes lifecycle status, reason, interfaces)
+   - `statusJSON`: error details (only when `eventType == "Error"`)
+
+The proto definitions are available at `kubevirt.io/kubevirt/pkg/handler-launcher-com/notify/v1/` and `notify/info/`.
+
+**Minimal Go listener example:**
+```go
+import (
+    notifyv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/notify/v1"
+    notifyinfo "kubevirt.io/kubevirt/pkg/handler-launcher-com/notify/info"
+)
+
+type handler struct{}
+
+func (h *handler) HandleDomainEvent(ctx context.Context, req *notifyv1.DomainEventRequest) (*notifyv1.Response, error) {
+    log.Printf("Event: type=%s domain=%s", req.EventType, string(req.DomainJSON))
+    return &notifyv1.Response{Success: true}, nil
+}
+
+func (h *handler) HandleK8SEvent(ctx context.Context, req *notifyv1.K8SEventRequest) (*notifyv1.Response, error) {
+    return &notifyv1.Response{Success: true}, nil
+}
+
+// Register both services on a gRPC server listening on domain-notify-pipe.sock
 ```
 
 ### Volume Support

--- a/cmd/vmToPod.go
+++ b/cmd/vmToPod.go
@@ -29,6 +29,7 @@ var (
 	proxyPort        int
 	noPasst          bool
 	mountDevices     bool
+	notifySocketDir  string
 )
 
 func main() {
@@ -68,6 +69,7 @@ or piped through stdin:
 				transformer.WithAddConsoleProxy(addConsoleProxy, proxyImage, proxyPort),
 				transformer.WithForcePasst(!noPasst),
 				transformer.WithMountDevices(mountDevices),
+				transformer.WithNotifySocketDir(notifySocketDir),
 			)
 
 			var pod *k8sv1.Pod
@@ -106,6 +108,7 @@ or piped through stdin:
 	rootCmd.Flags().IntVar(&proxyPort, "proxy-port", 8080, "Port for the console proxy to listen on")
 	rootCmd.Flags().BoolVar(&noPasst, "no-passt", false, "Preserve original network bindings instead of converting to Passt (requires CNI plugins)")
 	rootCmd.Flags().BoolVar(&mountDevices, "mount-devices", true, "Mount KVM devices (/dev/kvm, /dev/vhost-net, /dev/net/tun) for standalone execution")
+	rootCmd.Flags().StringVar(&notifySocketDir, "notify-socket-dir", "", "Host directory to expose the KubeVirt notify socket for VM event monitoring")
 
 	consoleCmd := &cobra.Command{
 		Use:   "console <vm-name>",

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -41,6 +41,7 @@ type VMToPodTransformer struct {
 	ProxyPort       	int
 	ForcePasst      	bool
 	MountDevices    	bool
+	NotifySocketDir		string
 }
 
 type TransformerOption func(*VMToPodTransformer)
@@ -80,6 +81,12 @@ func WithForcePasst(enabled bool) TransformerOption {
 func WithMountDevices(enabled bool) TransformerOption {
 	return func(t *VMToPodTransformer) {
 		t.MountDevices = enabled
+	}
+}
+
+func WithNotifySocketDir(dir string) TransformerOption {
+	return func(t *VMToPodTransformer) {
+		t.NotifySocketDir = dir
 	}
 }
 
@@ -220,6 +227,10 @@ func (t *VMToPodTransformer) transformBytes(data []byte) (*k8sv1.Pod, error) {
 
 	if t.MountDevices {
 		mountHostDevices(pod, vmi)
+	}
+
+	if t.NotifySocketDir != "" {
+		exposeNotifySocket(pod, t.NotifySocketDir)
 	}
 
 	cleanupForStandalone(pod, vmi)
@@ -384,6 +395,39 @@ func mountDevice(pod *k8sv1.Pod, volumeName, devicePath string, pathType *k8sv1.
 			break
 		}
 	}
+}
+
+func exposeNotifySocket(pod *k8sv1.Pod, hostDir string) {
+	hostPathDir := k8sv1.HostPathDirectoryOrCreate
+
+	for i, v := range pod.Spec.Volumes {
+		if v.Name == "public" {
+			pod.Spec.Volumes[i].VolumeSource = k8sv1.VolumeSource{
+				HostPath: &k8sv1.HostPathVolumeSource{
+					Path: hostDir,
+					Type: &hostPathDir,
+				},
+			}
+			break
+		}
+	}
+
+	// The hostPath is created with root ownership. Virt-launcher runs as UID 107
+	// and needs to write to this directory. Prepend an init container to fix permissions.
+	nonRoot := false
+	uid := int64(0)
+	pod.Spec.InitContainers = append([]k8sv1.Container{{
+		Name:    "fix-notify-permissions",
+		Image:   pod.Spec.Containers[0].Image,
+		Command: []string{"sh", "-c", "chmod 777 /var/run/kubevirt"},
+		VolumeMounts: []k8sv1.VolumeMount{
+			{Name: "public", MountPath: "/var/run/kubevirt"},
+		},
+		SecurityContext: &k8sv1.SecurityContext{
+			RunAsUser:    &uid,
+			RunAsNonRoot: &nonRoot,
+		},
+	}}, pod.Spec.InitContainers...)
 }
 
 func detectGPUVendor(deviceName string) string {

--- a/pkg/transformer/transformer_test.go
+++ b/pkg/transformer/transformer_test.go
@@ -499,6 +499,83 @@ spec:
 	})
 }
 
+func TestNotifySocketExposure(t *testing.T) {
+	findVolume := func(pod *k8sv1.Pod, name string) *k8sv1.Volume {
+		for i := range pod.Spec.Volumes {
+			if pod.Spec.Volumes[i].Name == name {
+				return &pod.Spec.Volumes[i]
+			}
+		}
+		return nil
+	}
+
+	t.Run("replaces public emptyDir with hostPath", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+		tmpFile, err := os.CreateTemp("", "vm.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+
+		pod, err := NewVMToPodTransformer(WithNotifySocketDir("/tmp/notify/testvm")).Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		vol := findVolume(pod, "public")
+		require.NotNil(t, vol)
+		require.NotNil(t, vol.HostPath, "public volume should be hostPath when notify socket is enabled")
+		require.Equal(t, "/tmp/notify/testvm", vol.HostPath.Path)
+
+		// Check init container for permissions fix
+		found := false
+		for _, c := range pod.Spec.InitContainers {
+			if c.Name == "fix-notify-permissions" {
+				found = true
+				require.Contains(t, c.Command[2], "chmod 777 /var/run/kubevirt")
+				break
+			}
+		}
+		require.True(t, found, "should have fix-notify-permissions init container")
+	})
+
+	t.Run("disabled keeps emptyDir", func(t *testing.T) {
+		vmYAML := []byte(`
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes: []
+`)
+		tmpFile, err := os.CreateTemp("", "vm.yaml")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.Write(vmYAML)
+		require.NoError(t, err)
+
+		pod, err := NewVMToPodTransformer().Transform(tmpFile.Name())
+		require.NoError(t, err)
+
+		vol := findVolume(pod, "public")
+		require.NotNil(t, vol)
+		require.Nil(t, vol.HostPath, "public volume should remain emptyDir when notify socket is not enabled")
+	})
+}
+
 func TestDataVolumeError(t *testing.T) {
 	t.Run("DataVolume volume produces clear error with alternatives", func(t *testing.T) {
 		vmYAML := []byte(`


### PR DESCRIPTION
## Summary
- New `--notify-socket-dir` flag exposes the KubeVirt domain notify socket on the host
- Allows an external monitoring service to receive VM lifecycle events (started, stopped, crashed) via gRPC — no sidecar needed
- Includes init container to fix hostPath permissions for rootless podman
- README documents the gRPC protocol, message types, and a minimal Go listener example

## How it works
Virt-launcher inside the container connects to `domain-notify-pipe.sock` as a gRPC client. The monitoring service creates this socket on the host and listens for events. The `--notify-socket-dir` flag mounts the host directory into the container so virt-launcher can reach it.

The protocol has only two RPC methods:
- `HandleDomainEvent` — receives VM lifecycle changes with domain state as JSON
- `HandleK8SEvent` — receives Kubernetes-level events (guest panics, IO errors)

## Test plan
- [x] `go test ./...` — all tests pass (2 new tests)
- [x] `go build ./...` — clean compilation
- [x] End-to-end: started pod with `--notify-socket-dir`, verified host directory is accessible and VM runs normally
- [x] End-to-end: verified virt-launcher attempts to connect to notify socket (logs show connection attempts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)